### PR TITLE
Deprecated TextTheme attribute

### DIFF
--- a/lib/src/widgets/slide_action.dart
+++ b/lib/src/widgets/slide_action.dart
@@ -179,7 +179,7 @@ class IconSlideAction extends ClosableSlideAction {
             overflow: TextOverflow.ellipsis,
             style: Theme.of(context)
                 .primaryTextTheme
-                .caption!
+                .bodySmall!
                 .copyWith(color: foregroundColor ?? estimatedColor),
           ),
         ),


### PR DESCRIPTION
fix deprecated TextTheme attribute after upgrading to Flutter 3.22